### PR TITLE
Date format: option to display milliseconds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target/
 *.war
 *.ear
 hs_err_pid*
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -76,14 +76,13 @@
       <artifactId>commons-math3</artifactId>
       <version>${commons-math3.version}</version>
     </dependency>
-
-    <!-- optional deps for additional functionality -->
     <dependency>
       <groupId>org.apache.poi</groupId>
       <artifactId>poi</artifactId>
       <version>${poi.version}</version>
-      <optional>true</optional>
     </dependency>
+    
+    <!-- optional deps for additional functionality -->
     <dependency>
       <groupId>com.xeiam.xchart</groupId>
       <artifactId>xchart</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -81,13 +81,25 @@
       <artifactId>poi</artifactId>
       <version>${poi.version}</version>
     </dependency>
-    
-    <!-- optional deps for additional functionality -->
+    <dependency>
+      <groupId>org.aspectj</groupId>
+      <artifactId>aspectjweaver</artifactId>
+      <version>1.8.9</version>
+    </dependency>
+    <dependency>
+      <groupId>com.codahale.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>3.0.2</version>
+    </dependency>
+    <dependency>
+      <groupId>rhino</groupId>
+      <artifactId>js</artifactId>
+      <version>1.7R2</version>
+    </dependency>
     <dependency>
       <groupId>com.xeiam.xchart</groupId>
       <artifactId>xchart</artifactId>
       <version>${xchart.version}</version>
-      <optional>true</optional>
       <exclusions>
         <exclusion>
           <groupId>de.erichseifert.vectorgraphics2d</groupId>
@@ -96,18 +108,10 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>rhino</groupId>
-      <artifactId>js</artifactId>
-      <version>1.7R2</version>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>jline</groupId>
       <artifactId>jline</artifactId>
       <version>${jline.version}</version>
-      <optional>true</optional>
     </dependency>
-
     <!-- test deps -->
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/joinery/DataFrame.java
+++ b/src/main/java/joinery/DataFrame.java
@@ -212,11 +212,11 @@ implements Iterable<List<V>> {
      *
      * @param index the row names
      * @param columns the column names
-     * @param data the data
+     * @param dataIterator iterator on data
      */
     public DataFrame(final Collection<?> index, final Collection<?> columns,
-            final List<? extends List<? extends V>> data) {
-        final BlockManager<V> mgr = new BlockManager<V>(data);
+            final Iterator<? extends List<? extends V>> dataIterator) {
+        final BlockManager<V> mgr = new BlockManager<V>(dataIterator);
         mgr.reshape(
                 Math.max(mgr.size(), columns.size()),
                 Math.max(mgr.length(), index.size())
@@ -226,6 +226,18 @@ implements Iterable<List<V>> {
         this.columns = new Index(columns, mgr.size());
         this.index = new Index(index, mgr.length());
         this.groups = new Grouping();
+    }
+
+    /**
+     * Construct a new data frame using the specified data and indices.
+     *
+     * @param index the row names
+     * @param columns the column names
+     * @param data the data
+     */
+    public DataFrame(final Collection<?> index, final Collection<?> columns,
+                     final List<? extends List<? extends V>> data) {
+        this(index, columns, data.iterator());
     }
 
     private DataFrame(final Index index, final Index columns, final BlockManager<V> data, final Grouping groups) {

--- a/src/main/java/joinery/DataFrame.java
+++ b/src/main/java/joinery/DataFrame.java
@@ -24,18 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import com.codahale.metrics.annotation.Timed;
 
@@ -258,22 +247,20 @@ implements Iterable<List<V>> {
      * > df.columns();
      * [value] }</pre>
      *
-     * @param columns the new column names
+     * @param column the new column name
      * @return the data frame with the columns added
      */
-    public DataFrame<V> add(final Object ... columns) {
-        for (final Object column : columns) {
+    public DataFrame<V> add(final Object column) {
             final List<V> values = new ArrayList<V>(length());
             for (int r = 0; r < values.size(); r++) {
                 values.add(null);
             }
-            add(column, values);
-        }
+            addColumn(column, values);
         return this;
     }
 
     public DataFrame<V> add(final List<V> values) {
-        return add(length(), values);
+        return addColumn(length(), values);
     }
 
     /**
@@ -284,7 +271,7 @@ implements Iterable<List<V>> {
      *
      * <pre> {@code
      * > DataFrame<Object> df = new DataFrame<>();
-     * > df.add("value", Arrays.<Object>asList(1));
+     * > df.addColumn("value", Arrays.<Object>asList(1));
      * > df.columns();
      * [value] }</pre>
      *
@@ -292,7 +279,7 @@ implements Iterable<List<V>> {
      * @param values the new column values
      * @return the data frame with the column added
      */
-    public DataFrame<V> add(final Object column, final List<V> values) {
+    public DataFrame<V> addColumn(final Object column, final List<V> values) {
         columns.add(column, data.size());
         index.extend(values.size());
         data.add(values);
@@ -1271,6 +1258,21 @@ implements Iterable<List<V>> {
         return transformed;
     }
 
+    public <U> DataFrame<V> applyRows(Object newColumn, final SingleRowFunction<V> generate) {
+        final List<V> output = new ArrayList<>();
+        Map<Integer, Object> fields = columns.getFields();
+        for (final List<V> row : this) {
+            Map<Object, V> items = new HashMap<>();
+            for(Integer position: fields.keySet()){
+                items.put(fields.get(position), row.get(position));
+            }
+            V newValue = generate.apply(items);
+            output.add(newValue);
+        }
+        this.addColumn(newColumn, output);
+        return this;
+    }
+
     /**
      * Attempt to infer better types for object columns.
      *
@@ -2189,6 +2191,10 @@ implements Iterable<List<V>> {
 
     public interface RowFunction<I, O> {
         List<List<O>> apply(List<I> values);
+    }
+
+    public interface SingleRowFunction<I> {
+        I apply(Map<Object, I> values);
     }
 
     /**

--- a/src/main/java/joinery/impl/BlockManager.java
+++ b/src/main/java/joinery/impl/BlockManager.java
@@ -18,22 +18,19 @@
 
 package joinery.impl;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
 public class BlockManager<V> {
     private final List<List<V>> blocks;
 
-    public BlockManager() {
-        this(Collections.<List<V>>emptyList());
+    public BlockManager(final Collection<? extends Collection<? extends V>> data) {
+        this(data.iterator());
     }
 
-    public BlockManager(final Collection<? extends Collection<? extends V>> data) {
+    public BlockManager(final Iterator<? extends Collection<? extends V>> iterator) {
         blocks = new LinkedList<>();
-        for (final Collection<? extends V> col : data) {
+        while(iterator.hasNext()) {
+            Collection<? extends V> col = iterator.next();
             add(new ArrayList<>(col));
         }
     }

--- a/src/main/java/joinery/impl/Conversion.java
+++ b/src/main/java/joinery/impl/Conversion.java
@@ -226,19 +226,19 @@ public class Conversion {
                 for (V num : col) {
                     nums.add((Number)num);
                 }
-                newDf.add(columnName,nums);
+                newDf.addColumn(columnName,nums);
             } else if (Date.class.isAssignableFrom(colTypes.get(column))) {
                 List<Number> dates = new ArrayList<>();
                 for (V date : col) {
                     dates.add(new Double(((Date)date).getTime()));
                 }
-                newDf.add(columnName,dates);
+                newDf.addColumn(columnName,dates);
             } else if (Boolean.class.isAssignableFrom(colTypes.get(column))) {
                 List<Number> bools = new ArrayList<>();
                 for (V tVal : col) {
                     bools.add((Boolean)tVal ? 1.0 : 0.0);
                 }
-                newDf.add(columnName,bools);
+                newDf.addColumn(columnName, bools);
             } else if (String.class.isAssignableFrom(colTypes.get(column))) {
                 Set<String> namesUsed = new HashSet<String>();
                 List<Object> extra = template != null ? template.col(column) : null;
@@ -247,7 +247,7 @@ public class Conversion {
                 int cnt = 0;
                 for(List<Number> var : variable) {
                     String name = columnName + "$" + nameToValidName(vr.names[cnt++],namesUsed);;
-                    newDf.add(name, var);
+                    newDf.addColumn(name, var);
                 }
             }
         }

--- a/src/main/java/joinery/impl/Index.java
+++ b/src/main/java/joinery/impl/Index.java
@@ -18,15 +18,7 @@
 
 package joinery.impl;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import joinery.DataFrame;
 import joinery.DataFrame.RowFunction;
@@ -36,7 +28,7 @@ public class Index {
     private final Map<Object, Integer> index;
 
     public Index() {
-        this(Collections.<Object>emptyList());
+        this(Collections.emptyList());
     }
 
     public Index(final Collection<?> names) {
@@ -50,6 +42,14 @@ public class Index {
             final Object name = it.hasNext() ? it.next() : i;
             add(name, i);
         }
+    }
+
+    public Map<Integer, Object> getFields(){
+        Map<Integer, Object> map = new HashMap<>();
+        for(Object column: index.keySet()){
+            map.put(index.get(column), column);
+        }
+        return map;
     }
 
     public void add(final Object name, final Integer value) {

--- a/src/main/java/joinery/impl/Serialization.java
+++ b/src/main/java/joinery/impl/Serialization.java
@@ -195,7 +195,7 @@ public class Serialization {
                     cal.get(Calendar.HOUR_OF_DAY) == 0 &&
                         cal.get(Calendar.MINUTE) == 0 &&
                         cal.get(Calendar.SECOND) == 0 ?
-                    "yyyy-MM-dd" : "yyyy-MM-dd'T'HH:mm:ssXXX"
+                    "yyyy-MM-dd" : "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
                 );
             s = fmt.format(dt);
         } else {
@@ -300,7 +300,7 @@ public class Serialization {
             for (int c = 0; c < df.size(); c++) {
                 final Class<?> cls = types.get(c);
                 if (Date.class.isAssignableFrom(cls)) {
-                    procs[c] = new ConvertNullTo("", new FmtDate("yyyy-MM-dd'T'HH:mm:ssXXX"));
+                    procs[c] = new ConvertNullTo("", new FmtDate("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"));
                 } else {
                     procs[c] = new ConvertNullTo("");
                 }

--- a/src/main/java/joinery/impl/Serialization.java
+++ b/src/main/java/joinery/impl/Serialization.java
@@ -59,13 +59,13 @@ import org.supercsv.prefs.CsvPreference;
 public class Serialization {
 
     private static final String EMPTY_DF_STRING = "[empty data frame]";
-    private static final String DATE_FORMAT_DEFAULT = "yyyy-MM-dd'T'HH:mm:ssXXX";
-    private static final String DATE_FORMAT_FULL = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
     private static final String ELLIPSES = "...";
     private static final String NEWLINE = "\n";
     private static final String DELIMITER = "\t";
     private static final Object INDEX_KEY = new Object();
     private static final int    MAX_COLUMN_WIDTH = 20;
+    private static final String DATE_FORMAT_DEFAULT = "yyyy-MM-dd'T'HH:mm:ssXXX";
+    public static final String DATE_FORMAT_FULL = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
 
     public static String toString(final DataFrame<?> df, final int limit) {
         final int len = df.length();

--- a/src/main/java/joinery/impl/js/DataFrameAdapter.java
+++ b/src/main/java/joinery/impl/js/DataFrameAdapter.java
@@ -122,7 +122,7 @@ extends ScriptableObject {
 
     public static Scriptable jsFunction_add(final Context ctx, final Scriptable object, final Object[] args, final Function func) {
         if (args.length == 2 && args[1] instanceof NativeArray) {
-            return new DataFrameAdapter(object, cast(object).df.add(args[0], asList(args[1])));
+            return new DataFrameAdapter(object, cast(object).df.addColumn(args[0], asList(args[1])));
         }
         if (args.length == 1 && args[0] instanceof NativeArray) {
             return new DataFrameAdapter(object, cast(object).df.add(asList(args[0])));

--- a/src/test/java/joinery/DataFrameGroupByTest.java
+++ b/src/test/java/joinery/DataFrameGroupByTest.java
@@ -44,8 +44,8 @@ public class DataFrameGroupByTest {
     @Test
     public final void testGroupBy() {
         final DataFrame<Object> df = new DataFrame<>();
-        df.add("name", Arrays.<Object>asList("one", "two", "three", "four", "one", "two"));
-        df.add("value", Arrays.<Object>asList(1, 2, 3, 4, 5, 6));
+        df.addColumn("name", Arrays.<Object>asList("one", "two", "three", "four", "one", "two"));
+        df.addColumn("value", Arrays.<Object>asList(1, 2, 3, 4, 5, 6));
         final DataFrame<Object> grouped = df.groupBy(0).count();
         assertEquals(
                 "group by result has correct number of rows",
@@ -67,8 +67,8 @@ public class DataFrameGroupByTest {
     @Test(expected=IllegalArgumentException.class)
     public final void testGroupByInvalid() {
         new DataFrame<String>()
-            .add("name", Arrays.<String>asList("one", "two", "three", "four", "one", "two"))
-            .add("value", Arrays.<String>asList("1", "2", "3", "4", "1", "6"))
+            .addColumn("name", Arrays.<String>asList("one", "two", "three", "four", "one", "two"))
+            .addColumn("value", Arrays.<String>asList("1", "2", "3", "4", "1", "6"))
             .groupBy(0)
             .sum();
     }
@@ -76,9 +76,9 @@ public class DataFrameGroupByTest {
     @Test
     public final void testGroupByMultiple() {
         final DataFrame<Object> df = new DataFrame<>();
-        df.add("name", Arrays.<Object>asList("one", "two", "three", "four", "one", "two"));
-        df.add("category", Arrays.<Object>asList("alpha", "beta", "alpha", "beta", "alpha", "beta"));
-        df.add("value", Arrays.<Object>asList(1, 2, 3, 4, 5, 6));
+        df.addColumn("name", Arrays.<Object>asList("one", "two", "three", "four", "one", "two"));
+        df.addColumn("category", Arrays.<Object>asList("alpha", "beta", "alpha", "beta", "alpha", "beta"));
+        df.addColumn("value", Arrays.<Object>asList(1, 2, 3, 4, 5, 6));
         final Object[][] expected = new Object[][] {
                 new Object[] { "alpha", "one",   2 },
                 new Object[] { "beta",  "two",   2 },

--- a/src/test/java/joinery/DataFrameManipulationTest.java
+++ b/src/test/java/joinery/DataFrameManipulationTest.java
@@ -42,16 +42,18 @@ public class DataFrameManipulationTest {
                 "size is equal to number of columns",
                 1,
                 df.size()
-            );
+        );
     }
 
     @Test
     public final void testAddMultiple() {
-        df.add("one", "two", "three");
+        df.add("one")
+                .add("two")
+                .add("three");
         assertArrayEquals(
-                new String[] { "one", "two", "three" },
+                new String[]{"one", "two", "three"},
                 df.columns().toArray()
-            );
+        );
     }
 
     @Test
@@ -60,19 +62,19 @@ public class DataFrameManipulationTest {
         df.append(Arrays.<Object>asList(1));
         df.add("two");
         assertArrayEquals(
-                new String[] { "one", "two" },
+                new String[]{"one", "two"},
                 df.columns().toArray()
-            );
+        );
         assertArrayEquals(
-                new Object[] { 1, null },
+                new Object[]{1, null},
                 df.toArray()
-            );
+        );
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test(expected = IllegalArgumentException.class)
     public final void testAddExisting() {
         df.add("test")
-          .add("test");
+                .add("test");
     }
 
     @Test
@@ -83,25 +85,25 @@ public class DataFrameManipulationTest {
                 "original size is equal to number of columns",
                 2,
                 df.size()
-            );
+        );
         assertArrayEquals(
                 "original column list is correct",
-                new Object[] { "test1", "test2" },
+                new Object[]{"test1", "test2"},
                 df.columns().toArray()
-            );
+        );
         assertEquals(
                 "new size is equal to number of columns",
                 1,
                 newDf.size()
-            );
+        );
         assertArrayEquals(
                 "new column list is correct",
-                new Object[] { "test2" },
+                new Object[]{"test2"},
                 newDf.columns().toArray()
-            );
+        );
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test(expected = IllegalArgumentException.class)
     public final void testDropInvalid() {
         df.drop("does-not-exist");
     }
@@ -113,23 +115,23 @@ public class DataFrameManipulationTest {
                 "size is equal to number of columns",
                 1,
                 df.size()
-            );
+        );
         assertEquals(
                 "length is equal to number of rows",
                 1,
                 df.length()
-            );
+        );
         assertArrayEquals(
                 "column values are correct",
-                new Object[] { 1 },
+                new Object[]{1},
                 df.col(0).toArray()
-            );
+        );
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test(expected = IllegalArgumentException.class)
     public final void testAppendExisting() {
         df.add("test")
-          .append("one", Collections.emptyList())
-          .append("one", Collections.emptyList());
+                .append("one", Collections.emptyList())
+                .append("one", Collections.emptyList());
     }
 }

--- a/src/test/java/joinery/DataFramePlotTest.java
+++ b/src/test/java/joinery/DataFramePlotTest.java
@@ -80,6 +80,6 @@ public class DataFramePlotTest {
             dates.add(cal.getTime());
             cal.add(Calendar.DATE, -1);
         }
-        df.add("date", dates).reindex("date").plot();
+        df.addColumn("date", dates).reindex("date").plot();
     }
 }

--- a/src/test/java/joinery/DataFrameSelectionTest.java
+++ b/src/test/java/joinery/DataFrameSelectionTest.java
@@ -37,7 +37,7 @@ public class DataFrameSelectionTest {
 
     @Before
     public void setUp()
-    throws Exception {
+            throws Exception {
         final List<List<Object>> data = new ArrayList<>();
         final Collection<Object> rows = new ArrayList<>();
         final Collection<Object> cols = Arrays.<Object>asList("name", "value");
@@ -64,7 +64,7 @@ public class DataFrameSelectionTest {
                         return new Integer(150).equals(row.get(1));
                     }
                 }).length()
-            );
+        );
     }
 
     @Test
@@ -77,60 +77,64 @@ public class DataFrameSelectionTest {
                         return false;
                     }
                 }).length()
-            );
+        );
     }
 
     @Test
     public void testSelectIndex() {
         assertArrayEquals(
-                new String[] { "row15" },
+                new String[]{"row15"},
                 df.select(new DataFrame.Predicate<Object>() {
                     @Override
                     public Boolean apply(final List<Object> row) {
                         return new Integer(150).equals(row.get(1));
                     }
                 }).index().toArray()
-            );
+        );
     }
 
     @Test
     public void testSlice() {
         System.out.println(df.slice(10, 16, 1, 2));
         assertArrayEquals(
-                new Object[] { 100, 110, 120, 130, 140 },
+                new Object[]{100, 110, 120, 130, 140},
                 df.slice(10, 15, 1, 2).toArray()
-            );
+        );
     }
 
     @Test
     public void testSliceIndex() {
         assertArrayEquals(
-                new String[] { "row15" },
+                new String[]{"row15"},
                 df.slice(15, 16).index().toArray()
-            );
+        );
     }
 
     @Test
     public void testDropNaRows() {
         df = new DataFrame<Object>()
-                    .add("one", "two", "three")
-                    .append(Arrays.asList("a", null, "c"))
-                    .append(Arrays.asList("aa", "bb", "cc"));
+                .add("one")
+                .add("two")
+                .add("three")
+                .append(Arrays.asList("a", null, "c"))
+                .append(Arrays.asList("aa", "bb", "cc"));
         assertArrayEquals(
-                new Object[] { "aa", "bb", "cc" },
+                new Object[]{"aa", "bb", "cc"},
                 df.dropna().toArray()
-            );
+        );
     }
 
     @Test
     public void testDropNaColumns() {
         df = new DataFrame<Object>()
-                    .add("one", "two", "three")
-                    .append(Arrays.asList("a", null, "c"))
-                    .append(Arrays.asList("aa", "bb", "cc"));
+                .add("one")
+                .add("two")
+                .add("three")
+                .append(Arrays.asList("a", null, "c"))
+                .append(Arrays.asList("aa", "bb", "cc"));
         assertArrayEquals(
-                new Object[] { "a", "aa", "c", "cc" },
+                new Object[]{"a", "aa", "c", "cc"},
                 df.dropna(Axis.COLUMNS).toArray()
-            );
+        );
     }
 }

--- a/src/test/java/joinery/DataFrameSortByTest.java
+++ b/src/test/java/joinery/DataFrameSortByTest.java
@@ -38,8 +38,8 @@ public class DataFrameSortByTest {
         values = Arrays.<Object>asList(1, 2, 3, 4, 5, 6);
         Collections.shuffle(values);
 
-        df.add("name", Arrays.<Object>asList("one", "two", "three", "four", "one", "two"));
-        df.add("value", values);
+        df.addColumn("name", Arrays.<Object>asList("one", "two", "three", "four", "one", "two"));
+        df.addColumn("value", values);
     }
 
     @Test

--- a/src/test/java/joinery/DataFrameTimeseriesTest.java
+++ b/src/test/java/joinery/DataFrameTimeseriesTest.java
@@ -25,6 +25,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.List;
+import java.util.Locale;
 
 import joinery.DataFrame.Function;
 
@@ -38,6 +39,7 @@ public class DataFrameTimeseriesTest {
     @Before
     public void setUp()
     throws IOException {
+        Locale.setDefault(Locale.US);
         df = DataFrame.readCsv(ClassLoader.getSystemResourceAsStream("timeseries.csv"));
     }
 

--- a/src/test/java/joinery/DataFrameViewsTest.java
+++ b/src/test/java/joinery/DataFrameViewsTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertArrayEquals;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import joinery.DataFrame.Function;
 import joinery.DataFrame.RowFunction;
@@ -37,19 +38,39 @@ public class DataFrameViewsTest {
 
     @Test
     public void testTransform() {
+        DataFrame<Object> result = df.transform(new RowFunction<Object, Object>() {
+            @Override
+            public List<List<Object>> apply(final List<Object> values) {
+                return Arrays.asList(values, values);
+            }
+        });
         assertArrayEquals(
                 new Object[] {
-                    "a", "a", "aa", "aa",
-                    null, null, "bb", "bb",
-                    "c", "c", "cc", "cc"
+                        "a", "a", "aa", "aa",
+                        null, null, "bb", "bb",
+                        "c", "c", "cc", "cc"
                 },
-                df.transform(new RowFunction<Object, Object>() {
-                    @Override
-                    public List<List<Object>> apply(final List<Object> values) {
-                        return Arrays.asList(values, values);
-                    }
-                }).toArray()
-            );
+                result.toArray()
+        );
+    }
+
+    @Test
+    public void testApplyRows() {
+        df.applyRows("new_col", new DataFrame.SingleRowFunction<Object>() {
+            @Override
+            public String apply(final Map<Object, Object> values) {
+                return "->" + values.get("one") + "." + values.get("three");
+            }
+        });
+        assertArrayEquals(
+                new Object[] {
+                        "a", "aa",
+                        null, "bb",
+                        "c", "cc",
+                        "->a.c", "->aa.cc",
+                },
+                df.toArray()
+        );
     }
 
     @Test

--- a/src/test/java/joinery/doctest/DocTestSuite.java
+++ b/src/test/java/joinery/doctest/DocTestSuite.java
@@ -219,10 +219,8 @@ extends Suite {
                         if (expected != null) {
                             org.junit.Assert.assertEquals(expected, String.valueOf(value));
                         }
-                    } catch (final AssertionError err) {
+                    } catch (final AssertionError | Exception err) {
                         notifier.fireTestFailure(new Failure(getDescription(), err));
-                    } catch (final Exception ex) {
-                        notifier.fireTestFailure(new Failure(getDescription(), ex));
                     } finally {
                         notifier.fireTestFinished(getDescription());
                     }


### PR DESCRIPTION
The client can control the date format when serializing to CSV.
Had to make optional dependencies required in order for the tests to run out of the box.
The DataFrameTimeSeriesTest would not run on a JVM whose Locale is not US.