### PR TITLE
Changes for reading pipe delimited (|) files

### DIFF
--- a/src/main/java/joinery/impl/Serialization.java
+++ b/src/main/java/joinery/impl/Serialization.java
@@ -251,6 +251,9 @@ public class Serialization {
             case ";":
                 csvPreference = CsvPreference.EXCEL_NORTH_EUROPE_PREFERENCE;
                 break;
+            case "|":
+            	csvPreference  = new CsvPreference.Builder('"', '|', "\n").build();
+                break;
             default:
                 throw new IllegalArgumentException("Separator: " + separator + " is not currently supported");
         }
@@ -263,7 +266,7 @@ public class Serialization {
         		procs = new CellProcessor[header.size()];
                 df = new DataFrame<>(header);
         	} else {
-        		// Read the first row to figure out how many columns we have
+        		// Read the first row to figure out how many columns we have        		
         		reader.read();
         		header = new ArrayList<String>();
         		for (int i = 0; i < reader.length(); i++) {

--- a/src/main/java/joinery/impl/Serialization.java
+++ b/src/main/java/joinery/impl/Serialization.java
@@ -237,6 +237,7 @@ public class Serialization {
     throws IOException {
     	return readCsv(input,separator, numDefault,naString, true);
     }
+   
     
     public static DataFrame<Object> readCsv(final InputStream input, String separator, NumberDefault numDefault, String naString, boolean hasHeader)
     throws IOException {


### PR DESCRIPTION
This PR is  for handling of  #60 

As suggested by you , I have used `CsvPreference.Builder` . 

Tested it with a sample file for reading as dataframe and accessing columns. 
Everything worked fine AFAIK :smiley:  

Could you consider merging this?