### PR TITLE
Added Helper methods for using readCSV with java.nio.file.Path

### DIFF
--- a/src/main/java/joinery/DataFrame.java
+++ b/src/main/java/joinery/DataFrame.java
@@ -19,10 +19,7 @@
 package joinery;
 
 import java.awt.Container;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.lang.reflect.Array;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -2139,6 +2136,26 @@ implements Iterable<List<V>> {
     public static final DataFrame<Object> readCsv(final InputStream input, final String separator, final NumberDefault longDefault)
     throws IOException {
         return Serialization.readCsv(input, separator, longDefault, null);
+    }
+
+    public static final DataFrame<Object> readCsv(final File file)
+        throws IOException {
+        return Serialization.readCsv(file);
+    }
+
+    public static final DataFrame<Object> readCsv(final File file, final String separator)
+        throws IOException {
+        return Serialization.readCsv(file, separator, NumberDefault.LONG_DEFAULT, null);
+    }
+
+    public static final DataFrame<Object> readCsv(final File file, final String separator, final String naString)
+        throws IOException {
+        return Serialization.readCsv(file, separator, NumberDefault.LONG_DEFAULT, naString);
+    }
+
+    public static final DataFrame<Object> readCsv(final File file, final String separator, final String naString, final boolean hasHeader)
+        throws IOException {
+        return Serialization.readCsv(file, separator, NumberDefault.LONG_DEFAULT, naString, hasHeader);
     }
 
     /**

--- a/src/main/java/joinery/impl/Serialization.java
+++ b/src/main/java/joinery/impl/Serialization.java
@@ -18,15 +18,11 @@
 
 package joinery.impl;
 
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
+import java.io.*;
 import java.math.BigInteger;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.sql.ParameterMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -231,6 +227,21 @@ public class Serialization {
     throws IOException {
         return readCsv(file.contains("://") ?
                 new URL(file).openStream() : new FileInputStream(file), separator, numDefault, naString, hasHeader);
+    }
+
+    public static DataFrame<Object> readCsv(final File file)
+        throws IOException {
+        return readCsv(Files.newInputStream(file.toPath(), StandardOpenOption.READ));
+    }
+
+    public static DataFrame<Object> readCsv(final File file, String separator, NumberDefault numDefault, String naString)
+        throws IOException {
+        return readCsv(Files.newInputStream(file.toPath(), StandardOpenOption.READ), separator, numDefault,naString, true);
+    }
+
+    public static DataFrame<Object> readCsv(final File file, String separator, NumberDefault numDefault, String naString, boolean hasHeader)
+        throws IOException {
+            return readCsv(Files.newInputStream(file.toPath(), StandardOpenOption.READ), separator, numDefault,naString, hasHeader);
     }
 
     public static DataFrame<Object> readCsv(final InputStream input) 


### PR DESCRIPTION
Added some helper methods to `DataFrame` and `Serialization` to allow readCSV to take java.nio.file.Path