### PR TITLE
Nonstrict join between tow dataframes

### DIFF
--- a/src/main/java/joinery/DataFrame.java
+++ b/src/main/java/joinery/DataFrame.java
@@ -666,6 +666,31 @@ implements Iterable<List<V>> {
     }
 
     /**
+     * Return a new data frame created by performing a left outer join
+     * of this data frame with the argument and using the row indices
+     * as the join key.
+     *
+     * <pre> {@code
+     * > DataFrame<Object> left = new DataFrame<>("a", "b");
+     * > left.append("one", Arrays.asList(1, 2));
+     * > left.append("two", Arrays.asList(3, 4));
+     * > left.append("three", Arrays.asList(5, 6));
+     * > DataFrame<Object> right = new DataFrame<>("c", "d");
+     * > right.append("one", Arrays.asList(10, 20));
+     * > right.append("two", Arrays.asList(30, 40));
+     * > right.append("four", Arrays.asList(50, 60));
+     * > left.join(right)
+     * >     .index();
+     * [one, two, three] }</pre>
+     *
+     * @param other the other data frame
+     * @return the result of the join operation as a new data frame
+     */
+    public final DataFrame<V> nonStrictJoin(final DataFrame<V> other) {
+        return nonStrictJoin(other, JoinType.LEFT, null);
+    }
+
+    /**
      * Return a new data frame created by performing a join of this
      * data frame with the argument using the specified join type and
      * using the row indices as the join key.
@@ -676,6 +701,19 @@ implements Iterable<List<V>> {
      */
     public final DataFrame<V> join(final DataFrame<V> other, final JoinType join) {
         return join(other, join, null);
+    }
+
+    /**
+     * Return a new data frame created by performing a join of this
+     * data frame with the argument using the specified join type and
+     * using the row indices as the join key.
+     *
+     * @param other the other data frame
+     * @param join the join type
+     * @return the result of the join operation as a new data frame
+     */
+    public final DataFrame<V> nonStrictJoin(final DataFrame<V> other, final JoinType join) {
+        return nonStrictJoin(other, join, null);
     }
 
     /**
@@ -691,6 +729,18 @@ implements Iterable<List<V>> {
     }
 
     /**
+     * Return a new data frame created by performing a left outer join of this
+     * data frame with the argument using the specified key function.
+     *
+     * @param other the other data frame
+     * @param on the function to generate the join keys
+     * @return the result of the join operation as a new data frame
+     */
+    public final DataFrame<V> nonStrictJoin(final DataFrame<V> other, final KeyFunction<V> on) {
+        return nonStrictJoin(other, JoinType.LEFT, on);
+    }
+
+    /**
      * Return a new data frame created by performing a join of this
      * data frame with the argument using the specified join type and
      * the specified key function.
@@ -702,6 +752,20 @@ implements Iterable<List<V>> {
      */
     public final DataFrame<V> join(final DataFrame<V> other, final JoinType join, final KeyFunction<V> on) {
         return Combining.join(this, other, join, on);
+    }
+
+    /**
+     * Return a new data frame created by performing a join of this
+     * data frame with the argument using the specified join type and
+     * the specified key function.
+     *
+     * @param other the other data frame
+     * @param join the join type
+     * @param on the function to generate the join keys
+     * @return the result of the join operation as a new data frame
+     */
+    public final DataFrame<V> nonStrictJoin(final DataFrame<V> other, final JoinType join, final KeyFunction<V> on) {
+        return Combining.nonStrictJoin(this, other, join, on);
     }
 
     /**

--- a/src/main/java/joinery/DataFrame.java
+++ b/src/main/java/joinery/DataFrame.java
@@ -781,6 +781,18 @@ implements Iterable<List<V>> {
     }
 
     /**
+     * Return a new data frame created by performing a left outer join of
+     * this data frame with the argument using the column values as the join key.
+     *
+     * @param other the other data frame
+     * @param cols the indices of the columns to use as the join key
+     * @return the result of the join operation as a new data frame
+     */
+    public final DataFrame<V> nonStrictJoinOn(final DataFrame<V> other, final Integer ... cols) {
+        return nonStrictJoinOn(other, JoinType.LEFT, cols);
+    }
+
+    /**
      * Return a new data frame created by performing a join of this
      * data frame with the argument using the specified join type and
      * the column values as the join key.
@@ -792,6 +804,20 @@ implements Iterable<List<V>> {
      */
     public final DataFrame<V> joinOn(final DataFrame<V> other, final JoinType join, final Integer ... cols) {
         return Combining.joinOn(this, other, join, cols);
+    }
+
+    /**
+     * Return a new data frame created by performing a join of this
+     * data frame with the argument using the specified join type and
+     * the column values as the join key.
+     *
+     * @param other the other data frame
+     * @param join the join type
+     * @param cols the indices of the columns to use as the join key
+     * @return the result of the join operation as a new data frame
+     */
+    public final DataFrame<V> nonStrictJoinOn(final DataFrame<V> other, final JoinType join, final Integer ... cols) {
+        return Combining.nonStrictJoinOn(this, other, join, cols);
     }
 
     /**
@@ -807,6 +833,18 @@ implements Iterable<List<V>> {
     }
 
     /**
+     * Return a new data frame created by performing a left outer join of
+     * this data frame with the argument using the column values as the join key.
+     *
+     * @param other the other data frame
+     * @param cols the names of the columns to use as the join key
+     * @return the result of the join operation as a new data frame
+     */
+    public final DataFrame<V> nonStrictJoinOn(final DataFrame<V> other, final Object ... cols) {
+        return nonStrictJoinOn(other, JoinType.LEFT, cols);
+    }
+
+    /**
      * Return a new data frame created by performing a join of this
      * data frame with the argument using the specified join type and
      * the column values as the join key.
@@ -818,6 +856,20 @@ implements Iterable<List<V>> {
      */
     public final DataFrame<V> joinOn(final DataFrame<V> other, final JoinType join, final Object ... cols) {
         return joinOn(other, join, columns.indices(cols));
+    }
+
+    /**
+     * Return a new data frame created by performing a join of this
+     * data frame with the argument using the specified join type and
+     * the column values as the join key.
+     *
+     * @param other the other data frame
+     * @param join the join type
+     * @param cols the names of the columns to use as the join key
+     * @return the result of the join operation as a new data frame
+     */
+    public final DataFrame<V> nonStrictJoinOn(final DataFrame<V> other, final JoinType join, final Object ... cols) {
+        return nonStrictJoinOn(other, join, columns.indices(cols));
     }
 
     /**

--- a/src/main/java/joinery/impl/Combining.java
+++ b/src/main/java/joinery/impl/Combining.java
@@ -84,7 +84,7 @@ public class Combining {
                         List<V> ttmp = new ArrayList<>();
                         ttmp.addAll(tmp);
                         ttmp.addAll(row != null ? row : Collections.<V>nCopies(right.columns().size(), null));
-                        df.append(counter++, ttmp);  // ?????index??
+                        df.append(counter++, ttmp);  // nonstrict join, key can be not unique
                     }
                 }
             }

--- a/src/main/java/joinery/impl/Combining.java
+++ b/src/main/java/joinery/impl/Combining.java
@@ -160,10 +160,10 @@ public class Combining {
         if (how == JoinType.OUTER) {
             for (final Map.Entry<Object, List<List<V>>> entry : how != JoinType.RIGHT ? rightMap.entrySet() : leftMap.entrySet()) {
                 List<List<V>> values = entry.getValue();
-                for(final List<V> tmp : values){
+                for (final List<V> tmp : values) {
                     final List<List<V>> rows = how != JoinType.RIGHT ? leftMap.get(entry.getKey()) : rightMap.get(entry.getKey());
                     if ((rows != null && rows.size() > 0) || how != JoinType.INNER) {
-                        for(List<V> row: rows) {
+                        for (List<V> row : rows) {
                             List<V> ttmp = new ArrayList<>();
                             ttmp.addAll(tmp);
                             ttmp.addAll(row != null ? row : Collections.<V>nCopies(right.columns().size(), null));
@@ -171,6 +171,7 @@ public class Combining {
                         }
                     }
                 }
+            }
         }
 
         return df;

--- a/src/main/java/joinery/impl/Combining.java
+++ b/src/main/java/joinery/impl/Combining.java
@@ -176,6 +176,19 @@ public class Combining {
         return df;
     }
 
+    public static <V> DataFrame<V> nonStrictJoinOn(final DataFrame<V> left, final DataFrame<V> right, final JoinType how, final Integer ... cols) {
+        return nonStrictJoin(left, right, how, new KeyFunction<V>() {
+            @Override
+            public Object apply(final List<V> value) {
+                final List<V> key = new ArrayList<>(cols.length);
+                for (final int col : cols) {
+                    key.add(value.get(col));
+                }
+                return Collections.unmodifiableList(key);
+            }
+        });
+    }
+
     public static <V> DataFrame<V> joinOn(final DataFrame<V> left, final DataFrame<V> right, final JoinType how, final Integer ... cols) {
         return join(left, right, how, new KeyFunction<V>() {
             @Override


### PR DESCRIPTION
For now, the key in dataframes those to be joined must be unique.

`
for (final List<V> row : left) {
            final Object name = leftIt.next();
            final Object key = on == null ? name : on.apply(row);
            if (leftMap.put(key, row) != null) {
                throw new IllegalArgumentException("generated key is not unique: " + key);
            }
        }

        for (final List<V> row : right) {
            final Object name = rightIt.next();
            final Object key = on == null ? name : on.apply(row);
            if (rightMap.put(key, row) != null) {
                throw new IllegalArgumentException("generated key is not unique: " + key);
            }
        }
`

But we just want to join two dataframe toghter, A has column 'dt' and B has column 'dt', then A and B can join based on 'dt' column. In this scenario, we should not force A has distinct date values..


So, I add a new API called nonStrictJoinOn to solve this problem. 

FYI.