### PR TITLE
83

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ target/
 *.war
 *.ear
 hs_err_pid*
-.idea/workspace.xml

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target/
 *.war
 *.ear
 hs_err_pid*
+.idea/workspace.xml

--- a/src/main/java/joinery/DataFrame.java
+++ b/src/main/java/joinery/DataFrame.java
@@ -818,6 +818,33 @@ implements Iterable<List<V>> {
     }
 
     /**
+     * Concatenate the specified data frames with this data frame
+     * with specified join type and return the result.
+     *
+     * <pre> {@code
+     * > DataFrame<Object> left = new DataFrame<>("a", "b", "c");
+     * > left.append("one", Arrays.asList(1, 2, 3));
+     * > left.append("two", Arrays.asList(4, 5, 6));
+     * > left.append("three", Arrays.asList(7, 8, 9));
+     * > DataFrame<Object> right = new DataFrame<>("a", "b", "d");
+     * > right.append("one", Arrays.asList(10, 20, 30));
+     * > right.append("two", Arrays.asList(40, 50, 60));
+     * > right.append("four", Arrays.asList(70, 80, 90));
+     * > left.concat(JoinType.INNER, right).columns();
+     * [a, b] }</pre>  
+     * 
+     * @param join the join type (JoinType.INNER, JoinType.OUTER only)
+     * @param others the other data frames
+     * @throws IllegalArgumentException if the join type is not inner or outer
+     * 
+     * @return the data frame containing all the values
+     */
+    @SafeVarargs
+    public final DataFrame<V> concat(final JoinType join, final DataFrame<? extends V> ... others) {
+        return Combining.concat(this, join, others);
+    }
+
+    /**
      * Update the data frame in place by overwriting any null values with
      * any non-null values provided by the data frame arguments.
      *

--- a/src/test/java/joinery/DataFrameCombiningTest.java
+++ b/src/test/java/joinery/DataFrameCombiningTest.java
@@ -320,4 +320,28 @@ public class DataFrameCombiningTest {
                 left.concat(right).toArray()
             );
     }
+
+    @Test
+    public void testOuterConcat() {
+        assertArrayEquals(
+                new Object[] {
+                    1L, 2L, 3L, 1L, 2L, 4L,
+                    "a", "a", "a", null, null, null,
+                    10.0, 20.0, 30.0, 30.0, 40.0, 80.0,
+                    null, null, null, "b", "b", "b"
+                },
+                left.concat(JoinType.OUTER, right).toArray()
+            );
+    }
+
+    @Test
+    public void testInnerConcat() {
+        assertArrayEquals(
+                new Object[] {
+                    1L, 2L, 3L, 1L, 2L, 4L,
+                    10.0, 20.0, 30.0, 30.0, 40.0, 80.0,
+                },
+                left.concat(JoinType.INNER, right).toArray()
+            );
+    }
 }


### PR DESCRIPTION
## What?
Per #83,  I have mimicked the pandas.concat method to implement outer and inner concat for DataFrame, based on the pre-existing concat method in Combining class.
## Why?
Enhancement for v1.1 milestone.
## How?
- Modularized the combined DataFrame filling segment of concat.
- Implemented the inner and outer join based on the original concat.
- Added method and docstring to the DataFrame class.
## Testing?
I have added tested both inner and outer concat.
## Anything Else?
Performance of concat function can be further improved by improving the runtime of fillConcatDataFrame, such as by updating each combined column instead of by each index.