### PR TITLE
writeCsv() with row names

### DIFF
--- a/src/main/java/joinery/DataFrame.java
+++ b/src/main/java/joinery/DataFrame.java
@@ -2174,7 +2174,19 @@ implements Iterable<List<V>> {
      */
     public final void writeCsv(final String file)
     throws IOException {
-        Serialization.writeCsv(this, new FileOutputStream(file));
+        Serialization.writeCsv(this, file);
+    }
+
+    /**
+     * Write the data from this data frame to the specified file as csv.
+     *
+     * @param file the file to write
+     * @param writeRowNames whether to include row names
+     * @throws IOException if an error occurs writing the file
+     */
+    public final void writeCsv(final String file, final boolean writeRowNames)
+            throws IOException {
+        Serialization.writeCsv(this, file, writeRowNames);
     }
 
     /**
@@ -2187,6 +2199,18 @@ implements Iterable<List<V>> {
     public final void writeCsv(final OutputStream output)
     throws IOException {
         Serialization.writeCsv(this, output);
+    }
+
+    /**
+     * Write the data from this data frame to the provided output stream as csv.
+     *
+     * @param output
+     * * @param writeRowNames whether to include row names
+     * @throws IOException
+     */
+    public final void writeCsv(final OutputStream output, final boolean writeRowNames)
+            throws IOException {
+        Serialization.writeCsv(this, output, writeRowNames);
     }
 
     /**

--- a/src/main/java/joinery/impl/Serialization.java
+++ b/src/main/java/joinery/impl/Serialization.java
@@ -42,6 +42,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Collection;
 
 import org.apache.poi.hssf.usermodel.HSSFDataFormat;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
@@ -290,14 +291,79 @@ public class Serialization {
         }
     }
 
+    /**
+     * Write the data from data frame to the specified file as csv with no row names.
+     *
+     * @param output the file to write to
+     * @param df data frame to write from
+     * @throws IOException if an error occurs writing the file
+     */
     public static <V> void writeCsv(final DataFrame<V> df, final String output)
     throws IOException {
         writeCsv(df, new FileOutputStream(output));
     }
 
+    /**
+     * Write the data from data frame to the specified file as csv.
+     *
+     * @param output the file to write to
+     * @param df data frame to write from
+     * @param writeRowNames whether to include row names
+     * @throws IOException if an error occurs writing the file
+     */
+    public static <V> void writeCsv(final DataFrame<V> df, final String output, final boolean writeRowNames)
+            throws IOException {
+        writeCsv(df, new FileOutputStream(output), writeRowNames);
+    }
+
+    /**
+     * Write the data from data frame to the specified file as csv with no row names.
+     *
+     * @param output the file to write to
+     * @param df data frame to write from
+     * @throws IOException if an error occurs writing the file
+     */
     public static <V> void writeCsv(final DataFrame<V> df, final OutputStream output)
-    throws IOException {
+            throws IOException {
+        writeCsv(df, output, false);
+    }
+
+    /**
+     * Add row names to data frame as the
+     * first column.
+     *
+     * @param df data frame to add to
+     * @return data frame with the row names
+     */
+    public static <V> DataFrame<V> addRowNames(final DataFrame<V> df) {
+        DataFrame<V> dff = new DataFrame<>();
+        final List<V> indexes = new ArrayList<>((Collection<? extends V>) df.index());
+        dff.add("", indexes);
+        dff = df.join(dff, DataFrame.JoinType.RIGHT);
+        for (int c = 0; c < df.size(); c++) {
+            final int sizeOfCol = df.length();
+            for (int r = 0; r < sizeOfCol; r++) {
+                dff.set(r, c+1, df.get(r, c));
+            }
+        }
+        return dff;
+    }
+
+    /**
+     * Write the data from data frame to the specified file as csv.
+     *
+     * @param output the file to write to
+     * @param df data frame to write from
+     * @param writeRowNames whether to include row names
+     * @throws IOException if an error occurs writing the file
+     */
+    public static <V> void writeCsv(final DataFrame<V> df, final OutputStream output, final boolean writeRowNames)
+            throws IOException {
         try (CsvListWriter writer = new CsvListWriter(new OutputStreamWriter(output), CsvPreference.STANDARD_PREFERENCE)) {
+            if (writeRowNames) {
+                writeCsv(addRowNames(df), output, false);
+                return;
+            }
             final String[] header = new String[df.size()];
             final Iterator<Object> it = df.columns().iterator();
             for (int c = 0; c < df.size(); c++) {

--- a/src/test/java/joinery/DataFrameSerializationTest.java
+++ b/src/test/java/joinery/DataFrameSerializationTest.java
@@ -186,6 +186,65 @@ public class DataFrameSerializationTest {
         assertTrue("writeCsv does not throw due to non-string indices", true);
     }
 
+    /**
+     * Test to write a csv with row names enabled
+     *
+     * @throws IOException if an error occurs writing the file
+     */
+    @Test
+    public void testWriteCsvWithRowNames()
+            throws IOException {
+        df = new DataFrame<>(
+                Arrays.<Object>asList("row1", "row2", "row3", "row4", "row5", "row6"),
+                Arrays.<Object>asList("category", "name", "value"),
+                Arrays.asList(
+                        Arrays.<Object>asList("a", "a", "b", "b", "c", "c"),
+                        Arrays.<Object>asList("alpha", "bravo", "charlie", "delta", "echo", "foxtrot"),
+                        Arrays.<Object>asList(1, 2, 3, 4, 5, 6)
+                )
+        );
+        final File tmp = File.createTempFile(getClass().getName(), ".csv");
+        tmp.deleteOnExit();
+        df.writeCsv(tmp.getPath(), true);
+        for (int i = 0; i < df.size() + 1; i++) {
+            assertArrayEquals(
+                    "Checking if reading the csv has the row names",
+                    DataFrame.readCsv(ClassLoader.getSystemResourceAsStream("serialization_row_names.csv")).col(0).toArray(),
+                    DataFrame.readCsv(tmp.getPath()).col(0).toArray()
+            );
+        }
+    }
+
+
+    /**
+     * Test to write a csv with row names disabled
+     *
+     * @throws IOException if an error occurs writing the file
+     */
+    @Test
+    public void testWriteCsvWithoutRowNames()
+            throws IOException {
+        df = new DataFrame<>(
+                Arrays.<Object>asList("row1", "row2", "row3", "row4", "row5", "row6"),
+                Arrays.<Object>asList("category", "name", "value"),
+                Arrays.asList(
+                        Arrays.<Object>asList("a", "a", "b", "b", "c", "c"),
+                        Arrays.<Object>asList("alpha", "bravo", "charlie", "delta", "echo", "foxtrot"),
+                        Arrays.<Object>asList(1, 2, 3, 4, 5, 6)
+                )
+        );
+        final File tmp = File.createTempFile(getClass().getName(), ".csv");
+        tmp.deleteOnExit();
+        df.writeCsv(new FileOutputStream(tmp), false);
+        for (int i = 0; i < df.size(); i++) {
+            assertArrayEquals(
+                    "Checking if reading the csv does not have the row names",
+                    DataFrame.readCsv(ClassLoader.getSystemResourceAsStream("serialization.csv")).col(0).toArray(),
+                    DataFrame.readCsv(tmp.getPath()).col(0).toArray()
+            );
+        }
+    }
+
     @Test(expected=FileNotFoundException.class)
     public void testReadXlsString()
     throws IOException {

--- a/src/test/resources/serialization_row_names.csv
+++ b/src/test/resources/serialization_row_names.csv
@@ -1,0 +1,7 @@
+,category,name,value
+row1,a,alpha,1
+row2,a,bravo,2
+row3,b,charlie,3
+row4,b,delta,4
+row5,c,echo,5
+row6,c,foxtrot,6


### PR DESCRIPTION
resolves #51 

To implement the feature, In DataFrame.java, I added overriding functions for writeCsv(...) with an additional parameter that specifies whether the user wants to add row names. In Serialization.java, I also included overriding functions and then in the main writeCvs(...) if the user wanted to write row names to the CSV, then the row name index is inserted into the first column of the data frame, which then is exported to a CSV. I also added two unit tests that test the new parameter (boolean writeRowNames) for when it is true and false. When it is false, I check to see if the row names column are not present in the csv file and the rest is the same. When it is true, I check to see if the row names column is present in the csv file and the rest is the same. My implementation passes these tests.